### PR TITLE
updating cli lib usage

### DIFF
--- a/tester.go
+++ b/tester.go
@@ -22,14 +22,14 @@ func main() {
 	app.Name = "tester"
 	app.Usage = "Make the rabbit cry"
 	app.Flags = []cli.Flag{
-		cli.StringFlag{"server, s", "rabbit-mq-test.cs1cloud.internal", "Hostname for RabbitMQ server"},
-		cli.IntFlag{"producer, p", 0, "Number of messages to produce, -1 to produce forever"},
-		cli.IntFlag{"wait, w", 0, "Number of nanoseconds to wait between publish events"},
-		cli.IntFlag{"consumer, c", -1, "Number of messages to consume. 0 consumes forever"},
-		cli.IntFlag{"bytes, b", 0, "number of extra bytes to add to the RabbitMQ message payload. About 50K max"},
-		cli.IntFlag{"concurrency, n", 50, "number of reader/writer Goroutines"},
-		cli.BoolFlag{"quiet, q", "Print only errors to stdout"},
-		cli.BoolFlag{"wait-for-ack, a", "Wait for an ack or nack after enqueueing a message"},
+		cli.StringFlag{Name: "server, s", Value: "rabbit-mq-test.cs1cloud.internal", Usage: "Hostname for RabbitMQ server"},
+		cli.IntFlag{Name: "producer, p", Value: 0, Usage: "Number of messages to produce, -1 to produce forever"},
+		cli.IntFlag{Name: "wait, w", Value: 0, Usage: "Number of nanoseconds to wait between publish events"},
+		cli.IntFlag{Name: "consumer, c", Value: -1, Usage: "Number of messages to consume. 0 consumes forever"},
+		cli.IntFlag{Name: "bytes, b", Value: 0, Usage: "number of extra bytes to add to the RabbitMQ message payload. About 50K max"},
+		cli.IntFlag{Name: "concurrency, n", Value: 50, Usage: "number of reader/writer Goroutines"},
+		cli.BoolFlag{Name: "quiet, q", Usage: "Print only errors to stdout"},
+		cli.BoolFlag{Name: "wait-for-ack, a", Usage: "Wait for an ack or nack after enqueueing a message"},
 	}
 	app.Action = func(c *cli.Context) {
 		runApp(c)


### PR DESCRIPTION
It looks like the cli library has been updated to require named parameters. Without this change, you see the following errors:

```
$ go get github.com/backstop/rabbit-mq-stress-tester
# github.com/backstop/rabbit-mq-stress-tester
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:25: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:26: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:27: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:28: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:29: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:30: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:31: too few values in struct initializer
src/github.com/backstop/rabbit-mq-stress-tester/tester.go:32: too few values in struct initializer
```
